### PR TITLE
Add CompactControlReadability option for Scalariform 0.1.1-SNAPSHOT support

### DIFF
--- a/src/main/scala/ScalariformOptions.scala
+++ b/src/main/scala/ScalariformOptions.scala
@@ -73,6 +73,12 @@ case class SpaceBeforeColon(enabled: Boolean) extends BooleanOption {
 //case class SpacesWithinPatternBinders(enabled: Boolean) extends BooleanOption {
 //  override def name = "spacesWithinPatternBinders"
 //}
+
+// Scalariform 0.1.1-SNAPSHOT (issue #22, pull request #26)
+//case class CompactControlReadability(enabled: Boolean) extends BooleanOption {
+//  override def name = "compactControlReadability"
+//}
+
 case object VerboseScalariform extends ScalariformOption {
   override def asArgument = "-v"
 }


### PR DESCRIPTION
Added commented out CompactControlReadability  boolean option for compatibility with Scalariform 0.1.1-SNAPSHOT (Scalariform issue #22, pull request #26)
